### PR TITLE
Add auto generated color palette block to the color selector window 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add auto generated color palette block to the color selector window
 - Add touch gesture support
   - If the `gesture` setting is enabled, the following gestures will become available:
     - Tap: switch to picker tool

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -155,7 +155,7 @@ impl ButtonKind {
             ButtonKind::BasicPressed => Size::square(64),
             ButtonKind::SliderLeft => Size::square(32),
             ButtonKind::SliderRight => Size::square(32),
-            ButtonKind::Middle => Size::from_wh(48, 24),
+            ButtonKind::Middle => Size::from_wh(48, 26),
         }
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -7,6 +7,7 @@ pub mod block;
 pub mod bottom_bar;
 pub mod button;
 pub mod color_config;
+pub mod color_palette;
 pub mod color_selector;
 pub mod config;
 pub mod draw_tool;

--- a/src/widget/color_palette.rs
+++ b/src/widget/color_palette.rs
@@ -1,6 +1,126 @@
-use pagurus::spatial::Region;
+use super::{FixedSizeWidget, Widget};
+use crate::{app::App, event::Event};
+use orfail::Result;
+use pagurus::{
+    image::Canvas,
+    spatial::{Position, Region, Size},
+};
 
 #[derive(Debug, Default)]
 pub struct ColorPaletteWidget {
-    _region: Region,
+    region: Region,
+}
+
+impl ColorPaletteWidget {
+    pub fn new(_app: &App) -> Self {
+        Self {
+            region: Region::default(),
+        }
+    }
+}
+
+impl Widget for ColorPaletteWidget {
+    fn region(&self) -> Region {
+        self.region
+    }
+
+    fn render(&self, app: &App, canvas: &mut Canvas) {
+        // self.render_color_preview(app, canvas);
+        // self.hsv.render_if_need(app, canvas);
+        // self.rgb.render_if_need(app, canvas);
+        // self.alpha.render_if_need(app, canvas);
+        // self.replace.render_if_need(app, canvas);
+    }
+
+    fn handle_event(&mut self, app: &mut App, event: &mut Event) -> Result<()> {
+        // let old_color = app.models().config.color.get();
+
+        // self.hsv.handle_event(app, event).or_fail()?;
+        // self.rgb.handle_event(app, event).or_fail()?;
+
+        // let alpha = self.alpha.body().value();
+        // self.alpha.handle_event(app, event).or_fail()?;
+        // if alpha != self.alpha.body().value() {
+        //     let mut c = app.models().config.color.get();
+        //     c.a = self.alpha.body().value() as u8;
+        //     app.models_mut().config.color.set(c);
+        // }
+
+        // let old_replace_mode = self.replace.body().is_on();
+        // self.replace.handle_event(app, event).or_fail()?;
+        // let new_replace_mode = self.replace.body().is_on();
+
+        // let new_color = app.models().config.color.get();
+        // if (old_color, old_replace_mode) != (new_color, new_replace_mode) {
+        //     if new_replace_mode {
+        //         self.replace_color(app).or_fail()?;
+        //         app.request_redraw(app.screen_size().to_region());
+        //     } else {
+        //         self.cancel_color_replace_if_need(app).or_fail()?;
+        //         app.request_redraw(self.region);
+        //     }
+        // }
+
+        Ok(())
+    }
+
+    fn children(&mut self) -> Vec<&mut dyn Widget> {
+        vec![
+            // &mut self.rgb,
+            // &mut self.hsv,
+            // &mut self.alpha,
+            // &mut self.replace,
+        ]
+    }
+}
+
+impl FixedSizeWidget for ColorPaletteWidget {
+    fn requiring_size(&self, app: &App) -> Size {
+        // let preview = Size::from_wh(0, COLOR_PREVIEW_HEIGHT);
+        // let hsv = self.hsv.requiring_size(app);
+        // let rgb = self.rgb.requiring_size(app);
+        // let alpha = self.alpha.requiring_size(app);
+        // let replace = self.alpha.requiring_size(app);
+
+        // Size::from_wh(
+        //     preview
+        //         .width
+        //         .max(rgb.width)
+        //         .max(hsv.width)
+        //         .max(alpha.width)
+        //         .max(replace.width),
+        //     preview.height
+        //         + MARGIN
+        //         + hsv.height
+        //         + MARGIN
+        //         + rgb.height
+        //         + MARGIN
+        //         + alpha.height
+        //         + MARGIN
+        //         + replace.height,
+        // )
+        Size::default()
+    }
+
+    fn set_position(&mut self, app: &App, position: Position) {
+        self.region = Region::new(position, self.requiring_size(app));
+
+        // let mut offset = position;
+        // offset.y += (COLOR_PREVIEW_HEIGHT + MARGIN) as i32;
+        // self.hsv
+        //     .set_region(app, Region::new(offset, self.hsv.requiring_size(app)));
+
+        // offset.y = self.hsv.region().end().y + MARGIN as i32;
+        // self.rgb
+        //     .set_region(app, Region::new(offset, self.rgb.requiring_size(app)));
+
+        // offset.y = self.rgb.region().end().y + MARGIN as i32;
+        // self.alpha
+        //     .set_region(app, Region::new(offset, self.alpha.requiring_size(app)));
+
+        // offset.y = self.alpha.region().end().y + MARGIN as i32;
+        // let mut replace_region = Region::new(offset, self.replace.requiring_size(app));
+        // replace_region.size.width = self.region.size.width;
+        // self.replace.set_region(app, replace_region);
+    }
 }

--- a/src/widget/color_palette.rs
+++ b/src/widget/color_palette.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use super::{button::ButtonWidget, FixedSizeWidget, Widget};
 use crate::{
     app::App,
@@ -14,6 +12,7 @@ use pagurus::{
     image::{Canvas, Rgba},
     spatial::{Contains, Position, Region, Size},
 };
+use std::collections::HashSet;
 
 #[derive(Debug, Default)]
 pub struct ColorPaletteWidget {
@@ -108,15 +107,21 @@ impl Widget for ColorPaletteWidget {
                 return Ok(());
             }
         }
-        for color in &mut self.buttons {
-            color.handle_event(app, event).or_fail()?;
+
+        for (button, &color) in self.buttons.iter_mut().zip(self.colors.iter()) {
+            button.handle_event(app, event).or_fail()?;
+            if button.take_clicked(app) {
+                app.models_mut().config.color.set(color);
+                break;
+            }
         }
+
         Ok(())
     }
 
     fn children(&mut self) -> Vec<&mut dyn Widget> {
         let mut children = Vec::new();
-        children.extend(self.buttons.iter_mut().map(|c| c as &mut dyn Widget));
+        children.extend(self.buttons.iter_mut().map(|b| b as &mut dyn Widget));
         children
     }
 }

--- a/src/widget/color_palette.rs
+++ b/src/widget/color_palette.rs
@@ -4,8 +4,10 @@ use super::{button::ButtonWidget, FixedSizeWidget, Widget};
 use crate::{
     app::App,
     asset::{ButtonKind, IconId},
+    canvas_ext::CanvasExt,
     color::Hsv,
     event::Event,
+    region_ext::RegionExt,
 };
 use orfail::{OrFail, Result};
 use pagurus::{
@@ -73,6 +75,18 @@ impl ColorPaletteWidget {
 
         colors
     }
+
+    fn render_color_label(&self, button: &ButtonWidget, color: Rgba, canvas: &mut Canvas) {
+        let offset = button.state().offset(button.kind()).y;
+        let mut label_region = button.region();
+        label_region.position.x += 2;
+        label_region.size.width -= 4;
+
+        label_region.position.y += 2 + offset;
+        label_region.size.height -= 4 + 4;
+
+        canvas.fill_rectangle(label_region.without_margin(2), color.into());
+    }
 }
 
 impl Widget for ColorPaletteWidget {
@@ -82,8 +96,9 @@ impl Widget for ColorPaletteWidget {
 
     fn render(&self, app: &App, canvas: &mut Canvas) {
         let mut canvas = canvas.mask_region(self.region);
-        for color in &self.buttons {
-            color.render(app, &mut canvas);
+        for (button, &color) in self.buttons.iter().zip(self.colors.iter()) {
+            button.render(app, &mut canvas);
+            self.render_color_label(button, color, &mut canvas);
         }
     }
 

--- a/src/widget/color_palette.rs
+++ b/src/widget/color_palette.rs
@@ -1,0 +1,6 @@
+use pagurus::spatial::Region;
+
+#[derive(Debug, Default)]
+pub struct ColorPaletteWidget {
+    _region: Region,
+}

--- a/src/widget/color_palette.rs
+++ b/src/widget/color_palette.rs
@@ -12,9 +12,9 @@ pub struct ColorPaletteWidget {
 }
 
 impl ColorPaletteWidget {
-    pub fn new(_app: &App) -> Self {
+    pub fn new(_app: &App, width: u32) -> Self {
         Self {
-            region: Region::default(),
+            region: Region::new(Position::default(), Size::from_wh(width, 0)),
         }
     }
 }
@@ -99,7 +99,7 @@ impl FixedSizeWidget for ColorPaletteWidget {
         //         + MARGIN
         //         + replace.height,
         // )
-        Size::default()
+        self.region.size
     }
 
     fn set_position(&mut self, app: &App, position: Position) {

--- a/src/widget/color_palette.rs
+++ b/src/widget/color_palette.rs
@@ -28,8 +28,11 @@ impl ColorPaletteWidget {
             .iter()
             .map(|_| ButtonWidget::new(ButtonKind::Middle, IconId::Null))
             .collect();
+        let height = ButtonWidget::new(ButtonKind::Middle, IconId::Null)
+            .requiring_size(app)
+            .height;
         Self {
-            region: Region::new(Position::default(), Size::from_wh(width, 0)),
+            region: Region::new(Position::default(), Size::from_wh(width, height)),
             colors,
             buttons,
         }
@@ -127,14 +130,8 @@ impl Widget for ColorPaletteWidget {
 }
 
 impl FixedSizeWidget for ColorPaletteWidget {
-    fn requiring_size(&self, app: &App) -> Size {
-        let mut size = self.region.size;
-        size.height = self
-            .buttons
-            .get(0)
-            .map(|c| c.requiring_size(app).height)
-            .unwrap_or_default();
-        size
+    fn requiring_size(&self, _app: &App) -> Size {
+        self.region.size
     }
 
     fn set_position(&mut self, app: &App, position: Position) {

--- a/src/widget/color_selector.rs
+++ b/src/widget/color_selector.rs
@@ -27,14 +27,13 @@ pub struct ColorSelectorWidget {
 impl ColorSelectorWidget {
     pub fn new(app: &App) -> Self {
         let color = app.models().config.color.get();
+        let hsv = HsvSelectorWidget::new(app);
+        let width = hsv.requiring_size(app).width;
         Self {
             region: Region::default(),
             old_color: color,
             replaced: false,
-            hsv: BlockWidget::new(
-                "HSV".parse().expect("unreachable"),
-                HsvSelectorWidget::new(app),
-            ),
+            hsv: BlockWidget::new("HSV".parse().expect("unreachable"), hsv),
             rgb: BlockWidget::new(
                 "RGB".parse().expect("unreachable"),
                 RgbSelectorWidget::new(app),
@@ -58,7 +57,7 @@ impl ColorSelectorWidget {
             ),
             palette: BlockWidget::new(
                 "PALETTE".parse().expect("unreachable"),
-                ColorPaletteWidget::new(app),
+                ColorPaletteWidget::new(app, width),
             ),
             replace: BlockWidget::new(
                 "REPLACE OLD COLOR PIXELS".parse().expect("unreachable"),


### PR DESCRIPTION
This pull request primarily introduces a new color palette feature to the project. This feature includes a new `ColorPaletteWidget` and its integration into the `ColorSelectorWidget`. Additionally, there are minor changes to the `ButtonKind` enumeration and the `CHANGELOG.md` file.

Here are the top five most important changes:

New Features:

* [`src/widget/color_palette.rs`](diffhunk://#diff-976737d99c77cf7e687557015f19dcd7bbfd4697d117610a1aebac68cd490bf6R1-R146): A new `ColorPaletteWidget` structure was created. This widget manages a color palette that can be used in the application. It includes methods for rendering, event handling, and setting positions.

Integration of New Features:

* [`src/widget/color_selector.rs`](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR1): The `ColorPaletteWidget` was integrated into the `ColorSelectorWidget`. This involved adding the `palette` field to the `ColorSelectorWidget` structure, handling events for the `palette`, rendering the `palette`, and adjusting the size and position of the `ColorSelectorWidget` to accommodate the `palette`. [[1]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR1) [[2]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bL12-R13) [[3]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR23-R36) [[4]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR58-R61) [[5]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR141-R143) [[6]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR161-R164) [[7]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR188) [[8]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR200-R205) [[9]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR214) [[10]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR224-R225) [[11]](diffhunk://#diff-b1f473afb7fbeaa6ef6587fe3f6dc2042e1286a5a8930af4028d4f508cb3f19bR247-R252)

Minor Changes:

* [`src/asset.rs`](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L158-R158): The size of the `ButtonKind::Middle` button was slightly increased.
* [`src/widget.rs`](diffhunk://#diff-773275389db96dfb0d4a26cd5896742ba2eaef15147bab7c1697bca8069762e8R10): A new module `color_palette` was added.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR17): A new change was added to the 'Added' section to reflect the addition of an auto-generated color palette block to the color selector window.