### PR TITLE
Remove unnecessary debug print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove unneccecary debug print
+- Remove unnecessary debug print
 
 ## [0.7.0] - 2024-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove unneccecary debug print
+
 ## [0.7.0] - 2024-08-06
 
 ### Removed

--- a/src/gesture.rs
+++ b/src/gesture.rs
@@ -16,11 +16,11 @@ pub struct PointerEvent {
 impl PointerEvent {
     pub fn to_mouse_event(self) -> MouseEvent {
         let position = self.position;
-        pagurus::dbg!(match self.event_type {
+        match self.event_type {
             EventType::Pointerdown => MouseEvent::Down { position },
             EventType::Pointermove => MouseEvent::Move { position },
             _ => MouseEvent::Up { position },
-        })
+        }
     }
 
     pub fn is_duplicate(self, other: Self) -> bool {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove unneccecary debug print
+
 ## [0.7.0] - 2024-08-06
 
 ### Removed

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Remove unneccecary debug print
+- Remove unnecessary debug print
 
 ## [0.7.0] - 2024-08-06
 


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes a change to the `PointerEvent` struct in the `src/gesture.rs` file to clean up the code by removing an unnecessary debug statement.

Code cleanup:

* [`src/gesture.rs`](diffhunk://#diff-6f0afb73a37aa17a9716308cab501342100bc5900a6334a703a6c1422083220aL19-R23): Removed the `pagurus::dbg!` debug statement from the `to_mouse_event` method in the `PointerEvent` struct.