### PR TITLE
Fix a bug in Safari that sometimes causes image files to fail to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix a bug in Safari that sometimes causes image files to fail to load (input.onchange event was not triggered)
 - Remove unnecessary debug print
 
 ## [0.7.0] - 2024-08-06

--- a/ts/src/pixcil.ts
+++ b/ts/src/pixcil.ts
@@ -247,7 +247,13 @@ class App {
     const input = document.createElement("input");
     input.setAttribute("type", "file");
     input.setAttribute("accept", "image/png");
+
+    // [NOTE] This is necessary to trigger the onchange event in Safari.
+    document.body.appendChild(input);
+
     input.onchange = async () => {
+      document.body.removeChild(input);
+
       const files = input.files;
       if (files === null || files.length === 0) {
         return;
@@ -263,6 +269,10 @@ class App {
         alert("Failed to load workspace file");
       }
     };
+    input.oncancel = async () => {
+      document.body.removeChild(input);
+    };
+
     input.click();
   }
 


### PR DESCRIPTION
Fixes https://github.com/sile/pixcil/issues/9

Copilot Summary
------------------

This pull request includes changes to fix a bug in Safari related to image file loading and improve the handling of file input elements. The most important changes include fixing the `input.onchange` event in Safari and ensuring the input element is removed from the DOM after use.

Bug fix and improvements:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12): Added a note about fixing a bug in Safari where the `input.onchange` event was not triggered, causing image files to fail to load.
* [`ts/src/pixcil.ts`](diffhunk://#diff-61d97887c279f9168afcd5023c81d5441a733a20284a9abd2d26e85abb531197R250-R256): Appended the input element to the document body to ensure the `input.onchange` event is triggered in Safari.
* [`ts/src/pixcil.ts`](diffhunk://#diff-61d97887c279f9168afcd5023c81d5441a733a20284a9abd2d26e85abb531197R250-R256): Removed the input element from the document body after the `input.onchange` event is triggered to clean up the DOM.
* [`ts/src/pixcil.ts`](diffhunk://#diff-61d97887c279f9168afcd5023c81d5441a733a20284a9abd2d26e85abb531197R272-R275): Added an `input.oncancel` event to remove the input element from the document body if the file selection is canceled.