### PR TITLE
Add an `APNG` setting to switch the export image format between APNG and sprite sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an `APNG` setting to switch the export image format between APNG and sprite sheet (a plain PNG file with animation frames lying adjacently)
+
 ### Fixed
 
 - Fix a bug in Safari that sometimes causes image files to fail to load (input.onchange event was not triggered)

--- a/src/model.rs
+++ b/src/model.rs
@@ -93,7 +93,7 @@ impl Models {
             }
 
             frames = vec![sprite_sheet_frame];
-            image_size.width *= frame_count as u16;
+            image_size.width *= frame_count;
             frame_count = 1;
         }
 

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -33,7 +33,13 @@ pub struct ConfigModel {
     pub silhouette_preview: bool,
     pub gesture: bool,
     pub background_color: Option<Rgba>,
-    pub apng: bool,
+    pub apng: Option<bool>,
+}
+
+impl ConfigModel {
+    pub fn apng(&self) -> bool {
+        self.apng.unwrap_or(true)
+    }
 }
 
 impl Serialize for ConfigModel {
@@ -76,7 +82,7 @@ impl Deserialize for ConfigModel {
             silhouette_preview: Deserialize::deserialize_or_default(reader).or_fail()?,
             gesture: Deserialize::deserialize_or_default(reader).or_fail()?,
             background_color: Deserialize::deserialize_or_default(reader).or_fail()?,
-            apng: Deserialize::deserialize_or(reader, true).or_fail()?,
+            apng: Deserialize::deserialize_or_default(reader).or_fail()?,
         })
     }
 }

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -33,6 +33,7 @@ pub struct ConfigModel {
     pub silhouette_preview: bool,
     pub gesture: bool,
     pub background_color: Option<Rgba>,
+    pub apng: bool,
 }
 
 impl Serialize for ConfigModel {
@@ -52,6 +53,7 @@ impl Serialize for ConfigModel {
         self.silhouette_preview.serialize(writer).or_fail()?;
         self.gesture.serialize(writer).or_fail()?;
         self.background_color.serialize(writer).or_fail()?;
+        self.apng.serialize(writer).or_fail()?;
         Ok(())
     }
 }
@@ -74,6 +76,7 @@ impl Deserialize for ConfigModel {
             silhouette_preview: Deserialize::deserialize_or_default(reader).or_fail()?,
             gesture: Deserialize::deserialize_or_default(reader).or_fail()?,
             background_color: Deserialize::deserialize_or_default(reader).or_fail()?,
+            apng: Deserialize::deserialize_or(reader, true).or_fail()?,
         })
     }
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -113,19 +113,6 @@ pub trait Deserialize: Sized {
             Self::deserialize(&mut buf.chain(reader)).or_fail()
         }
     }
-
-    fn deserialize_or<R: Read>(reader: &mut R, default: Self) -> Result<Self>
-    where
-        Self: Default,
-    {
-        let mut buf = [0];
-        let n = reader.read(&mut buf).or_fail()?;
-        if n == 0 {
-            Ok(default)
-        } else {
-            Self::deserialize(&mut buf.chain(reader)).or_fail()
-        }
-    }
 }
 
 impl<const N: usize> Deserialize for [u8; N] {

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -113,6 +113,19 @@ pub trait Deserialize: Sized {
             Self::deserialize(&mut buf.chain(reader)).or_fail()
         }
     }
+
+    fn deserialize_or<R: Read>(reader: &mut R, default: Self) -> Result<Self>
+    where
+        Self: Default,
+    {
+        let mut buf = [0];
+        let n = reader.read(&mut buf).or_fail()?;
+        if n == 0 {
+            Ok(default)
+        } else {
+            Self::deserialize(&mut buf.chain(reader)).or_fail()
+        }
+    }
 }
 
 impl<const N: usize> Deserialize for [u8; N] {

--- a/src/widget/config.rs
+++ b/src/widget/config.rs
@@ -28,6 +28,7 @@ pub struct ConfigWidget {
     layer_enable: BlockWidget<ToggleWidget>,
     animation_enable: BlockWidget<ToggleWidget>,
     fps: BlockWidget<NumberBoxWidget>,
+    apng: BlockWidget<ToggleWidget>,
 
     // Gesture settings
     gesture: BlockWidget<ToggleWidget>,
@@ -40,6 +41,7 @@ impl ConfigWidget {
         let silhouette_preview = app.models().config.silhouette_preview;
         let layer = app.models().config.layer;
         let animation = app.models().config.animation;
+        let apng = app.models().config.apng;
         let gesture = app.models().config.gesture;
         Self {
             region: Region::default(),
@@ -85,6 +87,10 @@ impl ConfigWidget {
                     Animation::MAX_FPS as u32,
                 ),
             ),
+            apng: BlockWidget::new(
+                "APNG".parse().expect("unreachable"),
+                ToggleWidget::new(apng),
+            ),
 
             // Gesture
             gesture: BlockWidget::new(
@@ -114,6 +120,7 @@ impl Widget for ConfigWidget {
         self.layer_enable.render_if_need(app, canvas);
         self.animation_enable.render_if_need(app, canvas);
         self.fps.render_if_need(app, canvas);
+        self.apng.render_if_need(app, canvas);
 
         // Gesture
         self.gesture.render_if_need(app, canvas);
@@ -177,6 +184,10 @@ impl Widget for ConfigWidget {
             .config
             .animation
             .set_fps(self.fps.body().value() as u8);
+
+        self.apng.handle_event(app, event).or_fail()?;
+        app.models_mut().config.apng = self.apng.body().is_on();
+
         if animation != app.models_mut().config.animation {
             app.request_redraw(app.screen_size().to_region());
         }
@@ -201,6 +212,7 @@ impl Widget for ConfigWidget {
             &mut self.layer_enable,
             &mut self.animation_enable,
             &mut self.fps,
+            &mut self.apng,
             // Gesture
             &mut self.gesture,
         ]
@@ -220,15 +232,30 @@ impl FixedSizeWidget for ConfigWidget {
         row3.width += MARGIN_X + self.frame_preview_scale.requiring_size(app).width;
         row3.width += MARGIN_X + self.silhouette.requiring_size(app).width;
 
-        // Layer / animation / gesture
+        // Layer / animation
         let mut row4 = self.layer_enable.requiring_size(app);
         row4.width += MARGIN_X + self.animation_enable.requiring_size(app).width;
         row4.width += MARGIN_X + self.fps.requiring_size(app).width;
-        row4.width += MARGIN_X + self.gesture.requiring_size(app).width;
+        row4.width += MARGIN_X + self.apng.requiring_size(app).width;
+
+        // gesture
+        let row5 = self.gesture.requiring_size(app);
 
         Size::from_wh(
-            row1.width.max(row2.width).max(row3.width).max(row4.width),
-            row1.height + MARGIN_Y + row2.height + MARGIN_Y + row3.height + MARGIN_Y + row4.height,
+            row1.width
+                .max(row2.width)
+                .max(row3.width)
+                .max(row4.width)
+                .max(row5.width),
+            row1.height
+                + MARGIN_Y
+                + row2.height
+                + MARGIN_Y
+                + row3.height
+                + MARGIN_Y
+                + row4.height
+                + MARGIN_Y
+                + row5.height,
         ) + MARGIN_X * 2
     }
 
@@ -266,7 +293,7 @@ impl FixedSizeWidget for ConfigWidget {
 
         region.consume_y(frame_preview_region.size.height + MARGIN_Y);
 
-        // Layer / animation / gesture
+        // Layer / animation
         let mut layer_enable_region = region;
         layer_enable_region.size = self.layer_enable.requiring_size(app);
         self.layer_enable.set_region(app, layer_enable_region);
@@ -282,8 +309,15 @@ impl FixedSizeWidget for ConfigWidget {
         fps_region.size = self.fps.requiring_size(app);
         self.fps.set_region(app, fps_region);
 
+        let mut apng_region = region;
+        apng_region.position.x = fps_region.end().x + MARGIN_X as i32;
+        apng_region.size = self.apng.requiring_size(app);
+        self.apng.set_region(app, apng_region);
+
+        region.consume_y(apng_region.size.height + MARGIN_Y);
+
+        // gesture
         let mut gesture_region = region;
-        gesture_region.position.x = fps_region.end().x + MARGIN_X as i32;
         gesture_region.size = self.gesture.requiring_size(app);
         self.gesture.set_region(app, gesture_region);
     }


### PR DESCRIPTION
Closes https://github.com/sile/pixcil/issues/5

Add an `APNG` setting to the configuration to switch the export image format between APNG and sprite sheet:
<img src="https://github.com/user-attachments/assets/7b1069e2-347f-41ce-9def-a2cd3fc4eaa5" width="300" />

Example Exported Files
--------------

Exported https://sile.github.io/doodles/2024/frog_jump.html as an APNG (default behavior):

![pixcil-20240907_112846](https://github.com/user-attachments/assets/9d35a3cf-bb67-4931-bc43-8c7638970389)

Exported the same file as a sprite sheet:
![pixcil-20240907_113113](https://github.com/user-attachments/assets/d4b53de7-a25f-40e5-83a0-91aed382ee35)

Copilot Summary
------------------

This pull request introduces support for APNG (Animated PNG) in the configuration model and updates the widget to handle this new feature. The most important changes include adding the APNG option to the `ConfigModel`, updating the `ConfigWidget` to render and handle APNG settings, and modifying the frame processing logic to accommodate non-APNG configurations.

### APNG Support in Configuration:

* [`src/model/config.rs`](diffhunk://#diff-86b83eaa816b75dd3942e24f43421ef069765123ec1dc4b89ce70fff0b620cb3R36-R42): Added a new `apng` field to `ConfigModel` along with its serialization and deserialization logic. Implemented a method to get the APNG setting with a default value. [[1]](diffhunk://#diff-86b83eaa816b75dd3942e24f43421ef069765123ec1dc4b89ce70fff0b620cb3R36-R42) [[2]](diffhunk://#diff-86b83eaa816b75dd3942e24f43421ef069765123ec1dc4b89ce70fff0b620cb3R62) [[3]](diffhunk://#diff-86b83eaa816b75dd3942e24f43421ef069765123ec1dc4b89ce70fff0b620cb3R85)

### Widget Updates for APNG:

* [`src/widget/config.rs`](diffhunk://#diff-9887b5eb3c94ae79ded4baa0890477c6f4946bdbe19ba3a79e5dafc1428f80f9R31): Added a new `apng` toggle widget to `ConfigWidget` and updated the widget's rendering and event-handling logic to include this new setting. [[1]](diffhunk://#diff-9887b5eb3c94ae79ded4baa0890477c6f4946bdbe19ba3a79e5dafc1428f80f9R31) [[2]](diffhunk://#diff-9887b5eb3c94ae79ded4baa0890477c6f4946bdbe19ba3a79e5dafc1428f80f9R44) [[3]](diffhunk://#diff-9887b5eb3c94ae79ded4baa0890477c6f4946bdbe19ba3a79e5dafc1428f80f9R90-R93) [[4]](diffhunk://#diff-9887b5eb3c94ae79ded4baa0890477c6f4946bdbe19ba3a79e5dafc1428f80f9R123) [[5]](diffhunk://#diff-9887b5eb3c94ae79ded4baa0890477c6f4946bdbe19ba3a79e5dafc1428f80f9R187-R190) [[6]](diffhunk://#diff-9887b5eb3c94ae79ded4baa0890477c6f4946bdbe19ba3a79e5dafc1428f80f9R215)

### Frame Processing Logic:

* [`src/model.rs`](diffhunk://#diff-6bd13171e8498a8adc17d13cef1f1b59f5fbd24ae4c72aeb4ce5f9b2b4703220L65-R66): Modified the frame processing logic to handle cases where APNG is not enabled, by creating a single sprite sheet frame and adjusting image size and frame count accordingly. [[1]](diffhunk://#diff-6bd13171e8498a8adc17d13cef1f1b59f5fbd24ae4c72aeb4ce5f9b2b4703220L65-R66) [[2]](diffhunk://#diff-6bd13171e8498a8adc17d13cef1f1b59f5fbd24ae4c72aeb4ce5f9b2b4703220L84-R98)