### PR TITLE
Add key bindings to switch tools

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+dev = "build --release --target wasm32-unknown-unknown"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added 
+
+- Add key bindings:
+  - TAB: Switch to next tool
+  - BACKTAB: Switch to prev tool
+  - p: Switch to PICK tool
+  - d: Switch to DRAW tool
+  - f: Switch to FILL tool
+  - e: Switch to ERASE tool
+  - s: Switch to SELECT tool
+  - m: Switch to MOVE tool
+
 ## [0.8.0] - 2025-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@ Features
 Key Bindings
 ------------
 
-| Key      | Action              |
-|----------|---------------------|
-| TAB      | Switch to next tool |
-| BACKTAB  | Switch to prev tool |
+| Key      | Action                |
+|----------|-----------------------|
+| TAB      | Switch to next tool   |
+| BACKTAB  | Switch to prev tool   |
+| p        | Switch to PICK tool   |
+| d        | Switch to DRAW tool   |
+| f        | Switch to FILL tool   |
+| e        | Switch to ERASE tool  |
+| s        | Switch to SELECT tool |
+| m        | Switch to MOVE tool   |
 
 How to build
 ------------

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Features
   - Created images are saved as PNG files (with additional metadata)
   - You can load existing PNG files and use Pixcil as a dot-by-dot PNG file editor
 
+Key Bindings
+------------
+
+| Key | Action |
+|-----|--------|
+|TAB| Switch to next tool |
+| BACKTAB | Switch to prev tool |
+
 How to build
 ------------
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Features
 Key Bindings
 ------------
 
-| Key | Action |
-|-----|--------|
-|TAB| Switch to next tool |
-| BACKTAB | Switch to prev tool |
+| Key      | Action              |
+|----------|---------------------|
+| TAB      | Switch to next tool |
+| BACKTAB  | Switch to prev tool |
 
 How to build
 ------------

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,5 @@
 use crate::gesture::{GestureEvent, PointerEvent};
-use pagurus::event::{Event as PagurusEvent, MouseEvent, TimeoutTag};
+use pagurus::event::{Event as PagurusEvent, KeyEvent, MouseEvent, TimeoutTag};
 use pagurus::spatial::Position;
 use pagurus::spatial::{Contains, Region};
 
@@ -17,6 +17,7 @@ pub enum Event {
         pointer: Option<PointerEvent>,
     },
     Gesture(GestureEvent),
+    Key(KeyEvent),
     Noop, // TODO: rename
 }
 
@@ -75,6 +76,7 @@ impl Event {
                     pointer: None,
                 }),
             },
+            PagurusEvent::Key(e) => Some(Self::Key(e)),
             _ => None,
         }
     }

--- a/src/game.rs
+++ b/src/game.rs
@@ -47,6 +47,10 @@ impl PixcilGame {
                     terminated = true;
                     app.request_redraw(window.region());
                 }
+
+                if matches!(event, Event::Key(_)) {
+                    break;
+                }
             }
 
             if terminated {

--- a/src/widget/select_box.rs
+++ b/src/widget/select_box.rs
@@ -1,6 +1,7 @@
 use super::{FixedSizeWidget, Widget, button::ButtonWidget};
 use crate::{app::App, event::Event};
 use orfail::{OrFail, Result};
+use pagurus::event::{Key, KeyEvent};
 use pagurus::image::Canvas;
 use pagurus::spatial::{Position, Region, Size};
 
@@ -64,6 +65,15 @@ impl SelectBoxWidget {
         }
         Ok(())
     }
+
+    fn handle_key_event(&mut self, app: &mut App, event: KeyEvent) -> Result<bool> {
+        match event.key {
+            Key::Tab => todo!(),
+            Key::BackTab => todo!(),
+            _ => {}
+        }
+        Ok(false)
+    }
 }
 
 impl Widget for SelectBoxWidget {
@@ -78,8 +88,13 @@ impl Widget for SelectBoxWidget {
     }
 
     fn handle_event(&mut self, app: &mut App, event: &mut Event) -> Result<()> {
-        self.prev_selected = None;
+        if let Event::Key(event) = event {
+            if self.handle_key_event(app, *event).or_fail()? {
+                return Ok(());
+            }
+        }
 
+        self.prev_selected = None;
         for (i, button) in self.buttons.iter_mut().enumerate() {
             button.handle_event(app, event).or_fail()?;
             if button.take_clicked(app) {

--- a/src/widget/select_box.rs
+++ b/src/widget/select_box.rs
@@ -1,7 +1,6 @@
 use super::{FixedSizeWidget, Widget, button::ButtonWidget};
 use crate::{app::App, event::Event};
 use orfail::{OrFail, Result};
-use pagurus::event::{Key, KeyEvent};
 use pagurus::image::Canvas;
 use pagurus::spatial::{Position, Region, Size};
 
@@ -47,6 +46,10 @@ impl SelectBoxWidget {
         Ok(())
     }
 
+    pub fn selected(&self) -> usize {
+        self.selected
+    }
+
     pub fn buttons(&self) -> &[ButtonWidget] {
         &self.buttons
     }
@@ -65,25 +68,6 @@ impl SelectBoxWidget {
         }
         Ok(())
     }
-
-    fn handle_key_event(&mut self, app: &mut App, event: KeyEvent) -> Result<bool> {
-        match event.key {
-            Key::Tab => {
-                let n = self.buttons.len();
-                let next = (self.selected + 1) % n;
-                self.select(app, next).or_fail()?;
-                return Ok(true);
-            }
-            Key::BackTab => {
-                let n = self.buttons.len();
-                let prev = (self.selected + n - 1) % n;
-                self.select(app, prev).or_fail()?;
-                return Ok(true);
-            }
-            _ => {}
-        }
-        Ok(false)
-    }
 }
 
 impl Widget for SelectBoxWidget {
@@ -98,12 +82,6 @@ impl Widget for SelectBoxWidget {
     }
 
     fn handle_event(&mut self, app: &mut App, event: &mut Event) -> Result<()> {
-        if let Event::Key(event) = event {
-            if self.handle_key_event(app, *event).or_fail()? {
-                return Ok(());
-            }
-        }
-
         self.prev_selected = None;
         for (i, button) in self.buttons.iter_mut().enumerate() {
             button.handle_event(app, event).or_fail()?;

--- a/src/widget/select_box.rs
+++ b/src/widget/select_box.rs
@@ -68,8 +68,18 @@ impl SelectBoxWidget {
 
     fn handle_key_event(&mut self, app: &mut App, event: KeyEvent) -> Result<bool> {
         match event.key {
-            Key::Tab => todo!(),
-            Key::BackTab => todo!(),
+            Key::Tab => {
+                let n = self.buttons.len();
+                let next = (self.selected + 1) % n;
+                self.select(app, next).or_fail()?;
+                return Ok(true);
+            }
+            Key::BackTab => {
+                let n = self.buttons.len();
+                let prev = (self.selected + n - 1) % n;
+                self.select(app, prev).or_fail()?;
+                return Ok(true);
+            }
             _ => {}
         }
         Ok(false)

--- a/src/widget/tool_box.rs
+++ b/src/widget/tool_box.rs
@@ -43,41 +43,27 @@ impl ToolBoxWidget {
         let Event::Key(event) = event else {
             return Ok(false);
         };
-        match event.key {
+        let index = match event.key {
             Key::Tab => {
                 let n = self.tools.buttons().len();
-                let next = (self.tools.selected() + 1) % n;
-                self.tools.select(app, next).or_fail()?;
-                return Ok(true);
+                (self.tools.selected() + 1) % n
             }
             Key::BackTab => {
                 let n = self.tools.buttons().len();
-                let prev = (self.tools.selected() + n - 1) % n;
-                self.tools.select(app, prev).or_fail()?;
-                return Ok(true);
+                (self.tools.selected() + n - 1) % n
             }
-            // pivot, pen, bucket, eraser, selection, hand
-            // Key::Char('p') | Key::Char('P') => {
-            //     if self.buttons.len() > 0 {
-            //         self.select(app, 0).or_fail()?;
-            //         return Ok(true);
-            //     }
-            // }
-            // Key::Char('h') | Key::Char('H') => {
-            //     if self.buttons.len() > 1 {
-            //         self.select(app, 1).or_fail()?;
-            //         return Ok(true);
-            //     }
-            // }
-            // Key::Char('e') | Key::Char('E') => {
-            //     if self.buttons.len() > 2 {
-            //         self.select(app, 2).or_fail()?;
-            //         return Ok(true);
-            //     }
-            // }
-            _ => {}
-        }
-        Ok(false)
+            Key::Char('p') => 0, // ToolKind::Pick
+            Key::Char('d') => 1, // ToolKind::Draw
+            Key::Char('f') => 2, // ToolKind::Fill
+            Key::Char('e') => 3, // ToolKind::Erase
+            Key::Char('s') => 4, // ToolKind::Select
+            Key::Char('m') => 5, // ToolKind::Move
+            _ => {
+                return Ok(false);
+            }
+        };
+        self.tools.select(app, index).or_fail()?;
+        Ok(true)
     }
 }
 


### PR DESCRIPTION
Related issue: #16 

## Copilot Summary

This pull request includes several changes to add key bindings for tool switching, update event handling, and improve the `SelectBoxWidget` and `ToolBoxWidget` functionalities. The most important changes are summarized below:

### Key Bindings and Documentation Updates:

* Added key bindings for tool switching in `CHANGELOG.md` and `README.md`:
  - TAB: Switch to next tool
  - BACKTAB: Switch to prev tool
  - p: Switch to PICK tool
  - d: Switch to DRAW tool
  - f: Switch to FILL tool
  - e: Switch to ERASE tool
  - s: Switch to SELECT tool
  - m: Switch to MOVE tool [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R29-R42)

### Event Handling:

* Updated `src/event.rs` to include `KeyEvent` in the `Event` enum and its handling:
  - Added `Key(KeyEvent)` variant to `Event` enum.
  - Modified `impl Event` to handle `PagurusEvent::Key`. [[1]](diffhunk://#diff-14da7c350de5742eaa248de110fefeae9b4b639c0358e26024d6040ccf174a41L2-R2) [[2]](diffhunk://#diff-14da7c350de5742eaa248de110fefeae9b4b639c0358e26024d6040ccf174a41R20) [[3]](diffhunk://#diff-14da7c350de5742eaa248de110fefeae9b4b639c0358e26024d6040ccf174a41R79)

* Updated `src/game.rs` to handle key events and break the loop on key event detection.

### Widget Enhancements:

* Added `selected` method to `SelectBoxWidget` to return the selected index.

* Enhanced `ToolBoxWidget` to handle key events for tool switching:
  - Added `handle_key_event` method to manage key events.
  - Updated `handle_event` method to utilize `handle_key_event` for key event processing. [[1]](diffhunk://#diff-6de1e3c6694b3224ff41eb14c8763123c70878a93320395f9415e663763c5a63R41-R67) [[2]](diffhunk://#diff-6de1e3c6694b3224ff41eb14c8763123c70878a93320395f9415e663763c5a63R108-R110)

### Configuration:

* Added a development build alias in `.cargo/config.toml` for building with the `wasm32-unknown-unknown` target.