### PR TITLE
Add key bindings for switching to previous and next frame using '<' and '>' keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Key Bindings
 | m        | Switch to MOVE tool   |
 | Ctrl-z   | undo                  |
 | Ctrl-y   | redo                  |
+| <        | Switch to prev frame  |
+| >        | Switch to next frame  |
 
 How to build
 ------------


### PR DESCRIPTION
Related issue: #16 

## Copilot Summary

This pull request introduces key bindings for navigating frames and updates the `MoveFrameWidget` to handle key events for frame navigation. The most important changes include adding new key bindings in the documentation and implementing the logic to handle these key events in the `MoveFrameWidget`.

Key bindings update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R45): Added key bindings for switching to the previous frame (`<`) and the next frame (`>`).

Implementation of key event handling:

* [`src/widget/move_frame.rs`](diffhunk://#diff-d23b54e9cccb125af01c27e82e2d72ee3e18ba3187844d8cd4b35cd66af68490R12): Imported the `Key` event to handle key inputs.
* [`src/widget/move_frame.rs`](diffhunk://#diff-d23b54e9cccb125af01c27e82e2d72ee3e18ba3187844d8cd4b35cd66af68490R26-R47): Added the `handle_key_event` method to the `MoveFrameWidget` struct to manage key events for frame navigation.
* [`src/widget/move_frame.rs`](diffhunk://#diff-d23b54e9cccb125af01c27e82e2d72ee3e18ba3187844d8cd4b35cd66af68490R72-R77): Updated the `handle_event` method to use the `handle_key_event` method and process frame navigation based on key presses. [[1]](diffhunk://#diff-d23b54e9cccb125af01c27e82e2d72ee3e18ba3187844d8cd4b35cd66af68490R72-R77) [[2]](diffhunk://#diff-d23b54e9cccb125af01c27e82e2d72ee3e18ba3187844d8cd4b35cd66af68490L64-R89)